### PR TITLE
Added Proxy Oauth Authenticator. Added Tests, Updated README, Fixed Linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ tap-googleads --about
 ### Getting A Refresh Token
 1. GET https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=client_id&redirect_uri=http://127.0.0.1&scope=https://www.googleapis.com/auth/adwords&state=autoidm&access_type=offline&prompt=select_account&include_granted_scopes=true
 1. POST https://www.googleapis.com/oauth2/v4/token?code={code}&client_id={client_id}&client_secret={client_secret}&redirect_uri=http://127.0.0.1&grant_type=authorization_code
-1. POST https://www.googleapis.com/oauth2/v4/token?refresh_token={refres_token}&client_id={client_id}&client_secret={client_secret}&grant_type=refresh_token
+1. POST https://www.googleapis.com/oauth2/v4/token?refresh_token={refresh_token}&client_id={client_id}&client_secret={client_secret}&grant_type=refresh_token
 
 
 ### Proxy OAuth Credentials

--- a/README.md
+++ b/README.md
@@ -17,20 +17,65 @@ pipx install tap-googleads
 
 ## Configuration
 
-### Get refresh token
-1. GET https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=client_id&redirect_uri=http://127.0.0.1&scope=https://www.googleapis.com/auth/adwords&state=autoidm&access_type=offline&prompt=select_account&include_granted_scopes=true
-1. POST https://www.googleapis.com/oauth2/v4/token?code={code}&client_id={client_id}&client_secret={client_secret}&redirect_uri=http://127.0.0.1&grant_type=authorization_code
-1. POST https://www.googleapis.com/oauth2/v4/token?refresh_token={refres_token}&client_id={client_id}&client_secret={client_secret]&grant_type=refresh_token
 ### Accepted Config Options
 
 - [ ] `Developer TODO:` Provide a list of config options accepted by the tap.
 
-A full list of supported settings and capabilities for this
-tap is available by running:
+### This tap supports two sets of configs:
 
+### Using Your Own Credentials
+
+Settings required to run this tap.
+
+- `client_id` (required)
+- `client_secret` (required)
+- `developer_token` (required)
+- `refresh_token` (required)
+- `customer_login_id` (required)
+- `customer_id` (required)
+- `start_date` (optional)
+
+How to get these settings can be found in the following Google Ads documentation:
+
+https://developers.google.com/adwords/api/docs/guides/authentication
+
+If you have installed the tap you can run the following commands to see more information about the tap.
 ```bash
 tap-googleads --about
 ```
+
+### Getting A Refresh Token
+1. GET https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=client_id&redirect_uri=http://127.0.0.1&scope=https://www.googleapis.com/auth/adwords&state=autoidm&access_type=offline&prompt=select_account&include_granted_scopes=true
+1. POST https://www.googleapis.com/oauth2/v4/token?code={code}&client_id={client_id}&client_secret={client_secret}&redirect_uri=http://127.0.0.1&grant_type=authorization_code
+1. POST https://www.googleapis.com/oauth2/v4/token?refresh_token={refres_token}&client_id={client_id}&client_secret={client_secret}&grant_type=refresh_token
+
+
+### Proxy OAuth Credentials
+
+To run the tap yourself It is highly recommended to use the [Using Your Own Credentials](#using-your-own-credentials) section listed above.
+
+These settings for handling your credentials through a Proxy OAuth Server, these settings are used by default in a [Matatika](https://www.matatika.com/) workspace.
+
+The benefit to using these settings in your [Matatika](https://www.matatika.com/) workspace is that you do not have to get or provide any of the OAuth credentials. All a user needs to do it allow the Matatika App permissions to access your GoogleAds data, and choose what `customer_login_id` and `customer_id` you want to get data from.
+
+All you need to provide in your [Matatika](https://www.matatika.com/) workspace are:
+- Permissions for our app to access your google account through an OAuth screen
+- `customer_login_id` (required)
+- `customer_id` (required)
+- `start_date` (optional)
+
+These are not intended for a user to set manually, as such setting them could cause some config conflicts that will now allow the tap to work correctly.
+
+Also set in by default in your [Matatika](https://www.matatika.com/) workspace environment:
+
+- `oauth_credentials.client_id`
+- `oauth_credentials_client_secret`
+- `oauth_credentials.authorization_url`
+- `oauth_credentials.scope`
+- `oauth_credentials.access_token`
+- `oauth_credentials.refresh_token`
+- `oauth_credentials.refresh_proxy_url`
+
 
 ### Source Authentication and Authorization
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -5,7 +5,7 @@ plugins:
   extractors:
   - name: tap-googleads
     namespace: tap_googleads
-    executable: ./tap-googleads.sh
+    pip_url: /home/dw/Documents/matatika/dan-stuff/tap-googleads
     capabilities:
     - state
     - catalog
@@ -24,7 +24,46 @@ plugins:
     - name: login_customer_id
       kind: password
     - name: start_date
-      value: '2010-01-01T00:00:00Z'
+    - name: oauth_credentials.client_id
+      kind: hidden
+      label: Optional - OAuth Client ID for use with a proxy refresh server
+      required: false
+      env_aliases:
+        - OAUTH_REFRESH_CLIENT_ID
+    - name: oauth_credentials.client_secret
+      kind: hidden
+      label: Optional - OAuth Client Secret for use with a proxy refresh server
+      required: false
+      env_aliases:
+        - OAUTH_REFRESH_CLIENT_SECRET
+    - name: oauth_credentials.authorization_url
+      kind: hidden
+      value: https://oauth2.googleapis.com/token
+      label: Optional - OAuth Authorization URL for use with a proxy refresh server
+      required: false
+    - name: oauth_credentials.scope
+      kind: hidden
+      value: https://www.googleapis.com/auth/adwords
+      label: Optional - OAuth Scope for use with a proxy refresh server
+      required: false
+    - name: oauth_credentials.access_token
+      kind: hidden
+      label: Access Token
+      required: false
+      env_aliases:
+        - OAUTH_CREDENTIALS_ACCESS_TOKEN
+    - name: oauth_credentials.refresh_token
+      kind: hidden
+      label: OAuth Refresh Token
+      required: false
+      env_aliases:
+        - OAUTH_CREDENTIALS_REFRESH_TOKEN
+    - name: oauth_credentials.refresh_proxy_url
+      kind: hidden
+      label: Optional - will be called with 'oauth_credentials.refresh_token' to refresh the access token via proxy refresh server
+      required: false
+      env_aliases:
+        - OAUTH_CREDENTIALS_REFRESH_PROXY_URL
     config:
       start_date: '2010-01-01T00:00:00Z'
   loaders:

--- a/meltano.yml
+++ b/meltano.yml
@@ -5,7 +5,7 @@ plugins:
   extractors:
   - name: tap-googleads
     namespace: tap_googleads
-    pip_url: /home/dw/Documents/matatika/dan-stuff/tap-googleads
+    executable: ./tap-googleads.sh
     capabilities:
     - state
     - catalog
@@ -25,17 +25,17 @@ plugins:
       kind: password
     - name: start_date
     - name: oauth_credentials.client_id
+      env_aliases:
+      - OAUTH_REFRESH_CLIENT_ID
       kind: hidden
       label: Optional - OAuth Client ID for use with a proxy refresh server
       required: false
-      env_aliases:
-        - OAUTH_REFRESH_CLIENT_ID
     - name: oauth_credentials.client_secret
+      env_aliases:
+      - OAUTH_REFRESH_CLIENT_SECRET
       kind: hidden
       label: Optional - OAuth Client Secret for use with a proxy refresh server
       required: false
-      env_aliases:
-        - OAUTH_REFRESH_CLIENT_SECRET
     - name: oauth_credentials.authorization_url
       kind: hidden
       value: https://oauth2.googleapis.com/token
@@ -47,23 +47,23 @@ plugins:
       label: Optional - OAuth Scope for use with a proxy refresh server
       required: false
     - name: oauth_credentials.access_token
-      kind: hidden
-      label: Access Token
-      required: false
       env_aliases:
-        - OAUTH_CREDENTIALS_ACCESS_TOKEN
+      - OAUTH_CREDENTIALS_ACCESS_TOKEN
+      kind: hidden
+      label: Optional - OAuth Access Token for use with a proxy refresh server
+      required: false
     - name: oauth_credentials.refresh_token
-      kind: hidden
-      label: OAuth Refresh Token
-      required: false
       env_aliases:
-        - OAUTH_CREDENTIALS_REFRESH_TOKEN
+      - OAUTH_CREDENTIALS_REFRESH_TOKEN
+      kind: hidden
+      label: Optional - OAuth Refresh Token for use with a proxy refresh server
+      required: false
     - name: oauth_credentials.refresh_proxy_url
-      kind: hidden
-      label: Optional - will be called with 'oauth_credentials.refresh_token' to refresh the access token via proxy refresh server
-      required: false
       env_aliases:
-        - OAUTH_CREDENTIALS_REFRESH_PROXY_URL
+      - OAUTH_CREDENTIALS_REFRESH_PROXY_URL
+      kind: hidden
+      label: Optional - OAuth Refresh Proxy URL is the URL for your proxy refresh server
+      required: false
     config:
       start_date: '2010-01-01T00:00:00Z'
   loaders:

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "backports.entry-points-selectable"
-version = "1.1.0"
+version = "1.1.1"
 description = "Compatibility shim providing selectable entry points for older implementations"
 category = "dev"
 optional = false
@@ -41,11 +41,11 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
 
 [[package]]
 name = "black"
-version = "21.9b0"
+version = "21.10b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -64,9 +64,9 @@ typing-extensions = ">=3.10.0.0"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-python2 = ["typed-ast (>=1.4.2)"]
+python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
@@ -172,7 +172,7 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.3.1"
+version = "3.3.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -206,7 +206,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.8.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -219,11 +219,11 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "5.3.0"
+version = "5.4.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -335,14 +335,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "21.0"
+version = "21.2"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3"
 
 [[package]]
 name = "pathspec"
@@ -420,11 +420,11 @@ python-versions = "*"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -436,7 +436,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycparser"
-version = "2.20"
+version = "2.21"
 description = "C parser in Python"
 category = "main"
 optional = false
@@ -479,14 +479,11 @@ test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner
 
 [[package]]
 name = "pyparsing"
-version = "3.0.1"
+version = "2.4.7"
 description = "Python parsing module"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pyrsistent"
@@ -547,7 +544,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "regex"
-version = "2021.10.23"
+version = "2021.11.10"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -570,6 +567,22 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "responses"
+version = "0.15.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+requests = ">=2.0"
+six = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "types-six", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
 
 [[package]]
 name = "simplejson"
@@ -670,7 +683,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.25.11"
+version = "2.26.0"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -699,7 +712,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.9.0"
+version = "20.10.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -715,7 +728,7 @@ platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
@@ -733,7 +746,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "<3.10,>=3.6.2"
-content-hash = "4ca66636815089e6b3010a22e2a0d3ddc378488cbd9bec5ad29c55044b559e54"
+content-hash = "c754adad84a2c1b5ba87cbd25aa35697faca4b0979ca8af73aaf610f650cce88"
 
 [metadata.files]
 atomicwrites = [
@@ -749,12 +762,12 @@ backoff = [
     {file = "backoff-1.8.0.tar.gz", hash = "sha256:c7187f15339e775aec926dc6e5e42f8a3ad7d3c2b9a6ecae7b535000f70cd838"},
 ]
 "backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
-    {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
+    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
+    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 black = [
-    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
-    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
+    {file = "black-21.10b0-py3-none-any.whl", hash = "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b"},
+    {file = "black-21.10b0.tar.gz", hash = "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -834,6 +847,8 @@ cryptography = [
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
+    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d"},
+    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89"},
     {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
     {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
     {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
@@ -859,8 +874,8 @@ distlib = [
     {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
 ]
 filelock = [
-    {file = "filelock-3.3.1-py3-none-any.whl", hash = "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f"},
-    {file = "filelock-3.3.1.tar.gz", hash = "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"},
+    {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
+    {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -871,12 +886,12 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
+    {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.3.0-py3-none-any.whl", hash = "sha256:7a65eb0d8ee98eedab76e6deb51195c67f8e575959f6356a6e15fd7e1148f2a3"},
-    {file = "importlib_resources-5.3.0.tar.gz", hash = "sha256:f2e58e721b505a79abe67f5868d99f8886aec8594c962c7490d0c22925f518da"},
+    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
+    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 inflection = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
@@ -937,8 +952,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+    {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
+    {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -984,16 +999,16 @@ ply = [
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pycparser = [
-    {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
-    {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
@@ -1008,8 +1023,8 @@ pyjwt = [
     {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.1-py3-none-any.whl", hash = "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"},
-    {file = "pyparsing-3.0.1.tar.gz", hash = "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531"},
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
@@ -1051,46 +1066,63 @@ pytzdata = [
     {file = "pytzdata-2020.1.tar.gz", hash = "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540"},
 ]
 regex = [
-    {file = "regex-2021.10.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d071dbe4b53c602edd87a7476ab23015a991374ddb228d941929ad7c8c922e"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34d870f9f27f2161709054d73646fc9aca49480617a65533fc2b4611c518e455"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fb698037c35109d3c2e30f2beb499e5ebae6e4bb8ff2e60c50b9a805a716f79"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cb46b542133999580ffb691baf67410306833ee1e4f58ed06b6a7aaf4e046952"},
-    {file = "regex-2021.10.23-cp310-cp310-win32.whl", hash = "sha256:5e9c9e0ce92f27cef79e28e877c6b6988c48b16942258f3bc55d39b5f911df4f"},
-    {file = "regex-2021.10.23-cp310-cp310-win_amd64.whl", hash = "sha256:ab7c5684ff3538b67df3f93d66bd3369b749087871ae3786e70ef39e601345b0"},
-    {file = "regex-2021.10.23-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de557502c3bec8e634246588a94e82f1ee1b9dfcfdc453267c4fb652ff531570"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee684f139c91e69fe09b8e83d18b4d63bf87d9440c1eb2eeb52ee851883b1b29"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5095a411c8479e715784a0c9236568ae72509450ee2226b649083730f3fadfc6"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b568809dca44cb75c8ebb260844ea98252c8c88396f9d203f5094e50a70355f"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eb672217f7bd640411cfc69756ce721d00ae600814708d35c930930f18e8029f"},
-    {file = "regex-2021.10.23-cp36-cp36m-win32.whl", hash = "sha256:a7a986c45d1099a5de766a15de7bee3840b1e0e1a344430926af08e5297cf666"},
-    {file = "regex-2021.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:6d7722136c6ed75caf84e1788df36397efdc5dbadab95e59c2bba82d4d808a4c"},
-    {file = "regex-2021.10.23-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f665677e46c5a4d288ece12fdedf4f4204a422bb28ff05f0e6b08b7447796d1"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:450dc27483548214314640c89a0f275dbc557968ed088da40bde7ef8fb52829e"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:129472cd06062fb13e7b4670a102951a3e655e9b91634432cfbdb7810af9d710"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a940ca7e7189d23da2bfbb38973832813eab6bd83f3bf89a977668c2f813deae"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:530fc2bbb3dc1ebb17f70f7b234f90a1dd43b1b489ea38cea7be95fb21cdb5c7"},
-    {file = "regex-2021.10.23-cp37-cp37m-win32.whl", hash = "sha256:ded0c4a3eee56b57fcb2315e40812b173cafe79d2f992d50015f4387445737fa"},
-    {file = "regex-2021.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:391703a2abf8013d95bae39145d26b4e21531ab82e22f26cd3a181ee2644c234"},
-    {file = "regex-2021.10.23-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be04739a27be55631069b348dda0c81d8ea9822b5da10b8019b789e42d1fe452"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ec99df95003f56edcd307db44f06fbeb708c4ccdcf940478067dd62353181e"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d1cdcda6bd16268316d5db1038965acf948f2a6f43acc2e0b1641ceab443623"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c186691a7995ef1db61205e00545bf161fb7b59cdb8c1201c89b333141c438a"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2b20f544cbbeffe171911f6ce90388ad36fe3fad26b7c7a35d4762817e9ea69c"},
-    {file = "regex-2021.10.23-cp38-cp38-win32.whl", hash = "sha256:c0938ddd60cc04e8f1faf7a14a166ac939aac703745bfcd8e8f20322a7373019"},
-    {file = "regex-2021.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:56f0c81c44638dfd0e2367df1a331b4ddf2e771366c4b9c5d9a473de75e3e1c7"},
-    {file = "regex-2021.10.23-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:80bb5d2e92b2258188e7dcae5b188c7bf868eafdf800ea6edd0fbfc029984a88"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1dae12321b31059a1a72aaa0e6ba30156fe7e633355e445451e4021b8e122b6"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1f2b59c28afc53973d22e7bc18428721ee8ca6079becf1b36571c42627321c65"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d134757a37d8640f3c0abb41f5e68b7cf66c644f54ef1cb0573b7ea1c63e1509"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0dcc0e71118be8c69252c207630faf13ca5e1b8583d57012aae191e7d6d28b84"},
-    {file = "regex-2021.10.23-cp39-cp39-win32.whl", hash = "sha256:a30513828180264294953cecd942202dfda64e85195ae36c265daf4052af0464"},
-    {file = "regex-2021.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:0f7552429dd39f70057ac5d0e897e5bfe211629652399a21671e53f2a9693a4e"},
-    {file = "regex-2021.10.23.tar.gz", hash = "sha256:f3f9a91d3cc5e5b0ddf1043c0ae5fa4852f18a1c0050318baf5fc7930ecc1f9c"},
+    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
+    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
+    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
+    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
+    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
+    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
+    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
+    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
+    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
+    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
+    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
+    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
+    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
+    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
+    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+responses = [
+    {file = "responses-0.15.0-py2.py3-none-any.whl", hash = "sha256:5955ad3468fe8eb5fb736cdab4943457b7768f8670fa3624b4e26ff52dfe20c0"},
+    {file = "responses-0.15.0.tar.gz", hash = "sha256:866757987d1962aa908d9c8b3185739faefd72a359e95459de0c2e4e5369c9b2"},
 ]
 simplejson = [
     {file = "simplejson-3.11.1-cp27-cp27m-win32.whl", hash = "sha256:38c2b563cd03363e7cb2bbba6c20ae4eaafd853a83954c8c8dd345ee391787bf"},
@@ -1168,8 +1200,8 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 types-requests = [
-    {file = "types-requests-2.25.11.tar.gz", hash = "sha256:b279284e51f668e38ee12d9665e4d789089f532dc2a0be4a1508ca0efd98ba9e"},
-    {file = "types_requests-2.25.11-py3-none-any.whl", hash = "sha256:ba1d108d512e294b6080c37f6ae7cb2a2abf527560e2b671d1786c1fc46b541a"},
+    {file = "types-requests-2.26.0.tar.gz", hash = "sha256:df5ec8c34b413a42ebb38e4f96bdeb68090b875bdfcc5138dc82989c95445883"},
+    {file = "types_requests-2.26.0-py3-none-any.whl", hash = "sha256:809b5dcd3c408ac39d11d593835b6aff32420b3e7ddb79c7f3e823330f040466"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
@@ -1181,8 +1213,8 @@ urllib3 = [
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.9.0-py2.py3-none-any.whl", hash = "sha256:1d145deec2da86b29026be49c775cc5a9aab434f85f7efef98307fb3965165de"},
-    {file = "virtualenv-20.9.0.tar.gz", hash = "sha256:bb55ace18de14593947354e5e6cd1be75fb32c3329651da62e92bf5d0aab7213"},
+    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
+    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ black = "^21.9b0"
 pydocstyle = "^6.1.1"
 mypy = "^0.910"
 types-requests = "^2.25.8"
+responses = "0.15.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tap_googleads/auth.py
+++ b/tap_googleads/auth.py
@@ -1,7 +1,92 @@
 """GoogleAds Authentication."""
 
 
+import json
+from datetime import datetime
+from typing import Optional
+import requests
+
+
+from singer import utils
 from singer_sdk.authenticators import OAuthAuthenticator, SingletonMeta
+from singer_sdk.helpers._util import utc_now
+from singer_sdk.streams import Stream as RESTStreamBase
+
+
+class ProxyGoogleAdsAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
+    """API Authenticator for Proxy OAuth 2.0 flows."""
+
+    def __init__(
+        self,
+        stream: RESTStreamBase,
+        auth_endpoint: Optional[str] = None,
+        oauth_scopes: Optional[str] = None,
+        auth_headers: Optional[dict] = None,
+        auth_body: Optional[dict] = None,
+    ) -> None:
+        """Create a new authenticator.
+
+        Args:
+            stream: The stream instance to use with this authenticator.
+            auth_endpoint: API username.
+            oauth_scopes: API password.
+        """
+        super().__init__(stream=stream)
+        self._auth_endpoint = auth_endpoint
+        self._oauth_scopes = oauth_scopes
+        self._auth_headers = auth_headers
+        self._auth_body = auth_body
+
+        # Initialize internal tracking attributes
+        self.access_token: Optional[str] = None
+        self.refresh_token: Optional[str] = None
+        self.last_refreshed: Optional[datetime] = None
+        self.expires_in: Optional[int] = None
+
+    def is_token_valid(self) -> bool:
+        """Check if token is valid.
+
+        Returns:
+            True if the token is valid (fresh).
+        """
+        if self.last_refreshed is None:
+            return False
+        if not self.expires_in:
+            return True
+        if self.expires_in > (utils.now() - self.last_refreshed).total_seconds():
+            return True
+        return False
+
+    # Authentication and refresh
+    def update_access_token(self) -> None:
+        """Update `access_token` along with: `last_refreshed` and `expires_in`.
+
+        Raises:
+            RuntimeError: When OAuth login fails.
+        """
+        request_time = utc_now()
+
+        token_response = requests.post(
+            self.auth_endpoint,
+            headers=self._auth_headers,
+            data=json.dumps(self._auth_body),
+        )
+        try:
+            token_response.raise_for_status()
+            self.logger.info("OAuth authorization attempt was successful.")
+        except Exception as ex:
+            raise RuntimeError(
+                f"Failed OAuth login, response was '{token_response.json()}'. {ex}"
+            )
+        token_json = token_response.json()
+        self.access_token = token_json["access_token"]
+        self.expires_in = token_json["expires_in"]
+        self.last_refreshed = request_time
+
+    @property
+    def oauth_request_body(self) -> dict:
+        """Define the OAuth request body for the GoogleAds API."""
+        return {}
 
 
 # The SingletonMeta metaclass makes your streams reuse the same authenticator instance.

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -1,9 +1,9 @@
 """REST client handling, including GoogleAdsStream base class."""
 
+from pathlib import Path
+from typing import Any, Dict, Optional
 import requests
 import singer
-from pathlib import Path
-from typing import Any, Dict, Optional, Union, List, Iterable
 
 from memoization import cached
 
@@ -38,9 +38,9 @@ class GoogleAdsStream(RESTStream):
         )
         auth_url = auth_url + f"&client_id={self.config.get('client_id')}"
         auth_url = auth_url + f"&client_secret={self.config.get('client_secret')}"
-        auth_url = auth_url + f"&grant_type=refresh_token"
+        auth_url = auth_url + "&grant_type=refresh_token"
 
-        if self.config.get("oauth_credentials", {}).get("refresh_proxy_url") == None:
+        if self.config.get("oauth_credentials", {}).get("refresh_proxy_url") is None:
             return GoogleAdsAuthenticator(stream=self, auth_endpoint=auth_url)
         else:
             auth_body = {}
@@ -105,23 +105,3 @@ class GoogleAdsStream(RESTStream):
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
         return params
-
-    def prepare_request_payload(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Optional[dict]:
-        """Prepare the data payload for the REST API request.
-
-        By default, no payload will be sent (return None).
-        """
-        # TODO: Delete this method if no payload is required. (Most REST APIs.)
-        return None
-
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        """Parse the response and return an iterator of result rows."""
-        # TODO: Parse response body and return a set of records.
-        yield from extract_jsonpath(self.records_jsonpath, input=response.json())
-
-    def post_process(self, row: dict, context: Optional[dict]) -> dict:
-        """As needed, append or transform raw data to match expected structure."""
-        # TODO: Delete this method if not needed.
-        return row

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -1,12 +1,11 @@
 """Stream type classes for tap-googleads."""
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, List, Iterable
+from typing import Any, Dict, Optional, Iterable
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_googleads.client import GoogleAdsStream
-from tap_googleads.auth import GoogleAdsAuthenticator
 
 # TODO: Delete this is if not using json files for schema definition
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
@@ -16,52 +15,57 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class CustomerStream(GoogleAdsStream):
     """Define custom stream."""
+
     @property
     def path(self):
-        return "/customers/"+self.config["customer_id"]
-    
+        return "/customers/" + self.config["customer_id"]
+
     name = "customers"
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "customer.json"
 
+
 class AccessibleCustomers(GoogleAdsStream):
     """Accessible Customers"""
-    path="/customers:listAccessibleCustomers"
+
+    path = "/customers:listAccessibleCustomers"
     name = "accessible_customers"
     primary_keys = None
     replication_key = None
-    #TODO add an assert for one record
-#    schema_filepath = SCHEMAS_DIR / "customer.json"
+    # TODO add an assert for one record
+    #    schema_filepath = SCHEMAS_DIR / "customer.json"
     schema = th.PropertiesList(
-            th.Property("resourceNames", th.ArrayType(th.StringType))
-            ).to_dict()
+        th.Property("resourceNames", th.ArrayType(th.StringType))
+    ).to_dict()
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return { "resourceNames":record["resourceNames"] }
+        return {"resourceNames": record["resourceNames"]}
+
 
 class CustomerHierarchyStream(GoogleAdsStream):
     """
-    Customer Hierarchy, inspiration from Google here 
+    Customer Hierarchy, inspiration from Google here
     https://developers.google.com/google-ads/api/docs/account-management/get-account-hierarchy.
 
     This stream is stictly to be the Parent Stream, to let all Child Streams
     know when to query the down stream apps.
 
     """
-    
-    #TODO add a seperate stream to get the Customer information and return i
+
+    # TODO add a seperate stream to get the Customer information and return i
     rest_method = "POST"
+
     @property
     def path(self):
-        #Paramas
+        # Paramas
         path = "/customers/{client_id}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"
         return path
-    
+
     @property
     def gaql(self):
         return """
@@ -76,14 +80,17 @@ class CustomerHierarchyStream(GoogleAdsStream):
         FROM customer_client
         WHERE customer_client.level <= 1
 	"""
+
     records_jsonpath = "$.results[*]"
     name = "customer_hierarchystream"
     primary_keys = ["customer_client.id"]
     replication_key = None
     parent_stream_type = AccessibleCustomers
-    #schema_filepath = SCHEMAS_DIR / "campaign.json"
+    # schema_filepath = SCHEMAS_DIR / "campaign.json"
     schema = th.PropertiesList(
-            th.Property("customerClient",th.ObjectType(
+        th.Property(
+            "customerClient",
+            th.ObjectType(
                 th.Property("resourceName", th.StringType),
                 th.Property("clientCustomer", th.StringType),
                 th.Property("level", th.StringType),
@@ -92,12 +99,12 @@ class CustomerHierarchyStream(GoogleAdsStream):
                 th.Property("descriptiveName", th.StringType),
                 th.Property("currencyCode", th.StringType),
                 th.Property("id", th.StringType),
-            ))
-            ).to_dict()
-    
+            ),
+        )
+    ).to_dict()
 
-    #Goal of this stream is to send to children stream a dict of
-    #login-customer-id:customer-id to query for all queries downstream
+    # Goal of this stream is to send to children stream a dict of
+    # login-customer-id:customer-id to query for all queries downstream
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
 
@@ -109,33 +116,36 @@ class CustomerHierarchyStream(GoogleAdsStream):
         Yields:
             One item per (possibly processed) record in the API.
         """
-        client_ids=[]
-        if (self.config["login_customer_id"]): 
+        client_ids = []
+        if self.config["login_customer_id"]:
             client_ids = [self.config["login_customer_id"]]
         else:
-            #TODO when implementing this the headers need to be set properly
+            # TODO when implementing this the headers need to be set properly
             client_ids = context["resourceNames"]
 
         for client in client_ids:
             client_id = client.split("/")[-1]
-            context["client_id"]=client_id
+            context["client_id"] = client_id
             for row in self.request_records(context):
                 row = self.post_process(row, context)
-                #Don't search Manager accounts as we can't query them for everything
-                if (row["customerClient"]["manager"] == True): continue
+                # Don't search Manager accounts as we can't query them for everything
+                if row["customerClient"]["manager"] == True:
+                    continue
                 yield row
-    
+
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return { "client_id":record["customerClient"]["id"] }
+        return {"client_id": record["customerClient"]["id"]}
+
 
 class GeotargetsStream(GoogleAdsStream):
     """Geotargets, worldwide, constant across all customers"""
+
     rest_method = "POST"
-    
+
     @property
     def path(self):
-        #Paramas
+        # Paramas
         path = "/customers/{login_customer_id}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
@@ -150,39 +160,46 @@ class GeotargetsStream(GoogleAdsStream):
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "geo_target_constant.json"
-    parent_stream_type = None #Override ReportsStream default as this is a constant
+    parent_stream_type = None  # Override ReportsStream default as this is a constant
+
 
 class ReportsStream(GoogleAdsStream):
     rest_method = "POST"
     parent_stream_type = CustomerHierarchyStream
+
     @property
     def gaql(self):
         raise NotImplementedError
-    
+
     @property
     def path(self):
-        #Paramas
+        # Paramas
         path = "/customers/{client_id}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"
         return path
-    
+
+
 class CampaignsStream(ReportsStream):
     """Define custom stream."""
+
     @property
     def gaql(self):
         return """
         SELECT campaign.id, campaign.name FROM campaign ORDER BY campaign.id
         """
+
     records_jsonpath = "$.results[*]"
     name = "campaign"
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign.json"
 
+
 class AdGroupsStream(ReportsStream):
     """Define custom stream."""
+
     @property
     def gaql(self):
         return """
@@ -215,11 +232,13 @@ class AdGroupsStream(ReportsStream):
        ad_group.ad_rotation_mode
        FROM ad_group 
        """
+
     records_jsonpath = "$.results[*]"
     name = "adgroups"
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "ad_group.json"
+
 
 class AdGroupsPerformance(ReportsStream):
     """AdGroups Performance"""
@@ -236,6 +255,7 @@ class AdGroupsPerformance(ReportsStream):
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "adgroups_performance.json"
 
+
 class CampaignPerformance(ReportsStream):
     """Campaign Performance"""
 
@@ -247,6 +267,7 @@ class CampaignPerformance(ReportsStream):
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign_performance.json"
+
 
 class CampaignPerformanceByAgeRangeAndDevice(ReportsStream):
     """Campaign Performance By Age Range and Device"""
@@ -260,6 +281,7 @@ class CampaignPerformanceByAgeRangeAndDevice(ReportsStream):
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_age_range_and_device.json"
 
+
 class CampaignPerformanceByGenderAndDevice(ReportsStream):
     """Campaign Performance By Age Range and Device"""
 
@@ -272,6 +294,7 @@ class CampaignPerformanceByGenderAndDevice(ReportsStream):
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_gender_and_device.json"
 
+
 class CampaignPerformanceByLocation(ReportsStream):
     """Campaign Performance By Age Range and Device"""
 
@@ -283,4 +306,3 @@ class CampaignPerformanceByLocation(ReportsStream):
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_location.json"
-

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -36,6 +36,7 @@ STREAM_TYPES = [
 
 class TapGoogleAds(Tap):
     """GoogleAds tap class."""
+
     name = "tap-googleads"
 
     # TODO: Add Descriptions
@@ -43,32 +44,32 @@ class TapGoogleAds(Tap):
         th.Property(
             "client_id",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property(
             "client_secret",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property(
             "developer_token",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property(
             "refresh_token",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property(
             "customer_id",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property(
             "login_customer_id",
             th.StringType,
-            required=True,
+            required=False,
         ),
     ).to_dict()
 

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -44,32 +44,26 @@ class TapGoogleAds(Tap):
         th.Property(
             "client_id",
             th.StringType,
-            required=False,
         ),
         th.Property(
             "client_secret",
             th.StringType,
-            required=False,
         ),
         th.Property(
             "developer_token",
             th.StringType,
-            required=False,
         ),
         th.Property(
             "refresh_token",
             th.StringType,
-            required=False,
         ),
         th.Property(
             "customer_id",
             th.StringType,
-            required=False,
         ),
         th.Property(
             "login_customer_id",
             th.StringType,
-            required=False,
         ),
     ).to_dict()
 

--- a/tap_googleads/tests/test_base_credentials.py
+++ b/tap_googleads/tests/test_base_credentials.py
@@ -1,3 +1,5 @@
+"""Tests the tap using a mock base credentials config."""
+
 import unittest
 import responses
 import singer
@@ -50,7 +52,8 @@ class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
 
         responses.add(
             responses.POST,
-            "https://www.googleapis.com/oauth2/v4/token?refresh_token=1234&client_id=1234&client_secret=1234&grant_type=refresh_token",
+            "https://www.googleapis.com/oauth2/v4/token?refresh_token=1234&client_id=1234"
+            + "&client_secret=1234&grant_type=refresh_token",
             json={"access_token": 12341234, "expires_in": 3622},
             status=200,
         )

--- a/tap_googleads/tests/test_base_credentials.py
+++ b/tap_googleads/tests/test_base_credentials.py
@@ -8,16 +8,6 @@ from tap_googleads.tap import TapGoogleAds
 
 import tap_googleads.tests.utils as test_utils
 
-SINGER_MESSAGES = []
-
-
-def accumulate_singer_messages(message):
-    """function to collect singer library write_message in tests"""
-    SINGER_MESSAGES.append(message)
-
-
-singer.write_message = accumulate_singer_messages
-
 
 class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
     """Test class for tap-googleads using base credentials"""
@@ -32,7 +22,9 @@ class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
             "developer_token": "1234",
         }
         responses.reset()
-        del SINGER_MESSAGES[:]
+        del test_utils.SINGER_MESSAGES[:]
+
+        singer.write_message = test_utils.accumulate_singer_messages
 
     def test_base_credentials_discovery(self):
         """Test basic discover sync with Bearer Token"""
@@ -67,7 +59,7 @@ class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
 
         tap.sync_all()
 
-        self.assertEqual(len(SINGER_MESSAGES), 3)
-        self.assertIsInstance(SINGER_MESSAGES[0], singer.SchemaMessage)
-        self.assertIsInstance(SINGER_MESSAGES[1], singer.RecordMessage)
-        self.assertIsInstance(SINGER_MESSAGES[2], singer.StateMessage)
+        self.assertEqual(len(test_utils.SINGER_MESSAGES), 3)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[0], singer.SchemaMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[1], singer.RecordMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[2], singer.StateMessage)

--- a/tap_googleads/tests/test_base_credentials.py
+++ b/tap_googleads/tests/test_base_credentials.py
@@ -1,0 +1,70 @@
+import unittest
+import responses
+import singer
+
+from tap_googleads.tap import TapGoogleAds
+
+import tap_googleads.tests.utils as test_utils
+
+SINGER_MESSAGES = []
+
+
+def accumulate_singer_messages(message):
+    """function to collect singer library write_message in tests"""
+    SINGER_MESSAGES.append(message)
+
+
+singer.write_message = accumulate_singer_messages
+
+
+class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
+    """Test class for tap-googleads using base credentials"""
+
+    def setUp(self):
+        self.mock_config = {
+            "client_id": "1234",
+            "client_secret": "1234",
+            "refresh_token": "1234",
+            "customer_id": "1234",
+            "login_customer_id": "1234",
+            "developer_token": "1234",
+        }
+        responses.reset()
+        del SINGER_MESSAGES[:]
+
+    def test_base_credentials_discovery(self):
+        """Test basic discover sync with Bearer Token"""
+
+        catalog = TapGoogleAds(self.mock_config).discover_streams()
+
+        # expect valid catalog to be discovered
+        self.assertEqual(len(catalog), 11, "Total streams from default catalog")
+
+    @responses.activate
+    def test_googleads_sync_accessible_customers(self):
+        """Test sync."""
+
+        tap = test_utils.set_up_tap_with_custom_catalog(
+            self.mock_config, ["accessible_customers"]
+        )
+
+        responses.add(
+            responses.POST,
+            "https://www.googleapis.com/oauth2/v4/token?refresh_token=1234&client_id=1234&client_secret=1234&grant_type=refresh_token",
+            json={"access_token": 12341234, "expires_in": 3622},
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            "https://googleads.googleapis.com/v8/customers:listAccessibleCustomers",
+            json=test_utils.accessible_customer_return_data,
+            status=200,
+        )
+
+        tap.sync_all()
+
+        self.assertEqual(len(SINGER_MESSAGES), 3)
+        self.assertIsInstance(SINGER_MESSAGES[0], singer.SchemaMessage)
+        self.assertIsInstance(SINGER_MESSAGES[1], singer.RecordMessage)
+        self.assertIsInstance(SINGER_MESSAGES[2], singer.StateMessage)

--- a/tap_googleads/tests/test_core.py
+++ b/tap_googleads/tests/test_core.py
@@ -15,10 +15,7 @@ SAMPLE_CONFIG = {
 # Run standard built-in tap tests from the SDK:
 def test_standard_tap_tests():
     """Run standard tap tests from the SDK."""
-    tests = get_standard_tap_tests(
-        TapGoogleAds,
-        config=SAMPLE_CONFIG
-    )
+    tests = get_standard_tap_tests(TapGoogleAds, config=SAMPLE_CONFIG)
     for test in tests:
         test()
 

--- a/tap_googleads/tests/test_proxy_oauth.py
+++ b/tap_googleads/tests/test_proxy_oauth.py
@@ -1,3 +1,5 @@
+"""Tests the tap using a mock proxy oauth config."""
+
 import unittest
 import responses
 import singer
@@ -69,7 +71,7 @@ class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
 
         tap.sync_all()
 
-        # Assert first oauth token call is using pre set refresh_proxy_url_auth "Bearer proxy_url_token"
+        # Assert first oauth token call is using pre set refresh_proxy_url_auth
 
         oauth_refresh_request_token = responses.calls[0].request.headers[
             "Authorization"

--- a/tap_googleads/tests/test_proxy_oauth.py
+++ b/tap_googleads/tests/test_proxy_oauth.py
@@ -1,0 +1,94 @@
+import unittest
+import responses
+import singer
+
+from tap_googleads.tap import TapGoogleAds
+import tap_googleads.tests.utils as test_utils
+
+SINGER_MESSAGES = []
+
+
+def accumulate_singer_messages(message):
+    """function to collect singer library write_message in tests"""
+    SINGER_MESSAGES.append(message)
+
+
+singer.write_message = accumulate_singer_messages
+
+
+class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
+    """Test class for tap-googleads using proxy refresh credentials"""
+
+    def setUp(self):
+        self.mock_config = {
+            "oauth_credentials": {
+                "client_id": "1234",
+                "client_secret": "1234",
+                "refresh_token": "1234",
+                "refresh_proxy_url": "http://localhost:8080/api/tokens/oauth2-google/token",
+                "refresh_proxy_url_auth": "Bearer proxy_url_token",
+                "scope": "https://www.googleapis.com/auth/adwords",
+                "authorization_url": "https://oauth2.googleapis.com/token",
+            },
+            "customer_id": "1234",
+            "login_customer_id": "1234",
+            "developer_token": "1234",
+        }
+        responses.reset()
+        del SINGER_MESSAGES[:]
+
+    def test_proxy_oauth_discovery(self):
+        """Test basic discover sync with proxy refresh credentials"""
+
+        catalog = TapGoogleAds(self.mock_config).discover_streams()
+
+        # Assert the correct number of default streams found
+        self.assertEqual(len(catalog), 11, "Total streams from default catalog")
+
+    @responses.activate
+    def test_proxy_oauth_refresh(self):
+        """Test proxy oauth refresh"""
+
+        tap = test_utils.set_up_tap_with_custom_catalog(
+            self.mock_config, ["accessible_customers"]
+        )
+
+        responses.add(
+            responses.POST,
+            "http://localhost:8080/api/tokens/oauth2-google/token",
+            json={"access_token": "refresh_token_updated", "expires_in": 3622},
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
+            "https://googleads.googleapis.com/v8/customers:listAccessibleCustomers",
+            json=test_utils.accessible_customer_return_data,
+            status=200,
+        )
+
+        tap.sync_all()
+
+        # Assert first oauth token call is using pre set refresh_proxy_url_auth "Bearer proxy_url_token"
+
+        oauth_refresh_request_token = responses.calls[0].request.headers[
+            "Authorization"
+        ]
+
+        self.assertEqual(oauth_refresh_request_token, "Bearer proxy_url_token")
+
+        # Assert that returned refresh token is used in the call.
+
+        accessible_customers_request_token = responses.calls[1].request.headers[
+            "Authorization"
+        ]
+
+        self.assertEqual(
+            accessible_customers_request_token, "Bearer refresh_token_updated"
+        )
+
+        # Assert that messages are output from sync (its actually working).
+        self.assertEqual(len(SINGER_MESSAGES), 3)
+        self.assertIsInstance(SINGER_MESSAGES[0], singer.SchemaMessage)
+        self.assertIsInstance(SINGER_MESSAGES[1], singer.RecordMessage)
+        self.assertIsInstance(SINGER_MESSAGES[2], singer.StateMessage)

--- a/tap_googleads/tests/test_proxy_oauth.py
+++ b/tap_googleads/tests/test_proxy_oauth.py
@@ -7,16 +7,6 @@ import singer
 from tap_googleads.tap import TapGoogleAds
 import tap_googleads.tests.utils as test_utils
 
-SINGER_MESSAGES = []
-
-
-def accumulate_singer_messages(message):
-    """function to collect singer library write_message in tests"""
-    SINGER_MESSAGES.append(message)
-
-
-singer.write_message = accumulate_singer_messages
-
 
 class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
     """Test class for tap-googleads using proxy refresh credentials"""
@@ -37,7 +27,8 @@ class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
             "developer_token": "1234",
         }
         responses.reset()
-        del SINGER_MESSAGES[:]
+        del test_utils.SINGER_MESSAGES[:]
+        singer.write_message = test_utils.accumulate_singer_messages
 
     def test_proxy_oauth_discovery(self):
         """Test basic discover sync with proxy refresh credentials"""
@@ -90,7 +81,7 @@ class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
         )
 
         # Assert that messages are output from sync (its actually working).
-        self.assertEqual(len(SINGER_MESSAGES), 3)
-        self.assertIsInstance(SINGER_MESSAGES[0], singer.SchemaMessage)
-        self.assertIsInstance(SINGER_MESSAGES[1], singer.RecordMessage)
-        self.assertIsInstance(SINGER_MESSAGES[2], singer.StateMessage)
+        self.assertEqual(len(test_utils.SINGER_MESSAGES), 3)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[0], singer.SchemaMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[1], singer.RecordMessage)
+        self.assertIsInstance(test_utils.SINGER_MESSAGES[2], singer.StateMessage)

--- a/tap_googleads/tests/utils.py
+++ b/tap_googleads/tests/utils.py
@@ -9,6 +9,13 @@ accessible_customer_return_data = {
     "resourceNames": ["customers/1234512345", "customers/5432154321"]
 }
 
+SINGER_MESSAGES = []
+
+
+def accumulate_singer_messages(message):
+    """function to collect singer library write_message in tests"""
+    SINGER_MESSAGES.append(message)
+
 
 def set_up_tap_with_custom_catalog(mock_config, stream_list):
 

--- a/tap_googleads/tests/utils.py
+++ b/tap_googleads/tests/utils.py
@@ -1,0 +1,29 @@
+""" Utilities used in this module """
+import singer
+from tap_googleads.tap import TapGoogleAds
+
+from singer_sdk.helpers._singer import Catalog
+from singer_sdk.helpers import _catalog
+
+accessible_customer_return_data = {
+    "resourceNames": ["customers/1234512345", "customers/5432154321"]
+}
+
+
+def set_up_tap_with_custom_catalog(mock_config, stream_list):
+
+    tap = TapGoogleAds(config=mock_config)
+    # Run discovery
+    tap.run_discovery()
+    # Get catalog from tap
+    catalog = Catalog.from_dict(tap.catalog_dict)
+    # Reset and re-initialize with an input catalog
+    _catalog.deselect_all_streams(catalog=catalog)
+    for stream in stream_list:
+        _catalog.set_catalog_stream_selected(
+            catalog=catalog,
+            stream_name=stream,
+            selected=True,
+        )
+    # Initialise tap with new catalog
+    return TapGoogleAds(config=mock_config, catalog=catalog.to_dict())


### PR DESCRIPTION
I mentioned on the Meltano Office Hours call the other week I had forked this tap for us to use, these are the changes I've added so far.

- Added Proxy OAuth Authenticator alongside the current auth
This meant having to make the tap settings not required. Unsure if you know of a work around?
- Added tests to prove both the Proxy OAuth & Current Authenticator work alongside each other.
- Updated the README to explain the new settings
- Fixed some minor linting issues.

The only other problem I'm running into at the moment is that we use the Meltano variant of target-postgres, which isn't playing nice with the expected primary key column names. 

Removing all expected primary keys fixes this but don't think that's a good solution, my plan is to check the differences between the record and schema singer messages and seeing whats happening. (The target does "unpack" column names sometimes).